### PR TITLE
docs: Add README with project management processes summary and docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# OctoAcme Project Management Docs
+
+Welcome to the central reference for program management processes used by OctoAcme. These documentation resources enable teams to deliver consistently, onboard quickly, and maintain clear standards for project execution.
+
+## Project Management Processes Summary
+
+OctoAcme follows a structured, phase-based lifecycle for all projects: **Initiation, Planning, Execution, Release, and Retrospective/Continuous Improvement**. The process begins with a clear problem statement, stakeholder identification, and measurable goals in a Project One-pager. Planning then turns ideas into actionable increments with prioritized backlogs, risk identification, and milestone mapping. Day-to-day execution is governed through daily standups, weekly syncs, and a project board workflow (Backlog, Ready, In Progress, In Review, QA, Done) to manage work progress, blockers, and delivery. Pull requests are kept small with automated CI checks, and at least one code review is required before merging.
+
+Quality assurance is incorporated at every stage with unit, integration, and smoke testing, mandatory security scanning, and both automated and manual QA for feature acceptances. Releases follow a standard checklist-based approach—ensuring all acceptance criteria, tests, and documentation are complete, and that rollback plans are in place. Risk management is proactive, using a living risk register, regular review cycles, and clear, level-based escalation paths. Finally, retrospectives are used to capture learnings and drive continuous improvement, fostering a culture of transparency, knowledge sharing, and iterative refinement.
+
+Roles are clearly defined: Project Managers coordinate delivery, Product Managers set priorities and measure success, Developers implement and test features, and QA ensures product quality. Regular, structured communication—standups, weekly PM-PdM syncs, and stakeholder updates—keeps everyone aligned and accountable.
+
+## Docs Index
+
+- [Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](octoacme-roles-and-personas.md)
+
+---
+
+This README is designed as a quick reference and onboarding accelerator. For details on how these living documents are maintained, see the general instructions and the issue templates in `.github/ISSUE_TEMPLATE/`.


### PR DESCRIPTION
This PR adds a README to the `docs/` folder summarizing OctoAcme's project management processes and providing quick links to all major documentation.

Closes #2